### PR TITLE
Add Structure Locator logging

### DIFF
--- a/src/main/java/net/oxcodsnet/roadarchitect/RoadArchitect.java
+++ b/src/main/java/net/oxcodsnet/roadarchitect/RoadArchitect.java
@@ -5,6 +5,8 @@ import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.oxcodsnet.roadarchitect.util.StructureLocator;
+
 public class RoadArchitect implements ModInitializer {
 	public static final String MOD_ID = "roadarchitect";
 
@@ -13,12 +15,14 @@ public class RoadArchitect implements ModInitializer {
 	// That way, it's clear which mod wrote info, warnings, and errors.
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-	@Override
-	public void onInitialize() {
-		// This code runs as soon as Minecraft is in a mod-load-ready state.
-		// However, some things (like resources) may still be uninitialized.
-		// Proceed with mild caution.
+        @Override
+        public void onInitialize() {
+                // This code runs as soon as Minecraft is in a mod-load-ready state.
+                // However, some things (like resources) may still be uninitialized.
+                // Proceed with mild caution.
 
-		LOGGER.info("Hello Fabric world!");
-	}
+                StructureLocator.init();
+                LOGGER.info("Hello Fabric world!");
+        }
 }
+

--- a/src/main/java/net/oxcodsnet/roadarchitect/util/StructureLocator.java
+++ b/src/main/java/net/oxcodsnet/roadarchitect/util/StructureLocator.java
@@ -1,0 +1,48 @@
+package net.oxcodsnet.roadarchitect.util;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockBox;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.gen.StructureAccessor;
+import net.minecraft.world.gen.structure.Structure;
+import net.minecraft.world.gen.structure.StructureStart;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.entry.RegistryEntry;
+
+import net.oxcodsnet.roadarchitect.RoadArchitect;
+
+public final class StructureLocator {
+    private StructureLocator() {}
+
+    public static void init() {
+        ServerChunkEvents.CHUNK_LOAD.register(StructureLocator::onChunkLoad);
+    }
+
+    private static void onChunkLoad(ServerWorld world, WorldChunk chunk) {
+        logStructures(world, chunk);
+    }
+
+    private static void logStructures(ServerWorld world, WorldChunk chunk) {
+        StructureAccessor accessor = world.getStructureAccessor();
+        Registry<Structure> registry = world.getRegistryManager().get(RegistryKeys.STRUCTURE);
+        ChunkSectionPos sectionPos = ChunkSectionPos.from(chunk.getPos(), world.getBottomSectionCoord());
+
+        for (Structure structure : registry) {
+            for (StructureStart start : accessor.getStructureStarts(sectionPos, structure)) {
+                if (start != null && start.hasChildren()) {
+                    BlockBox box = start.getBoundingBox();
+                    BlockPos center = box.getCenter();
+                    RoadArchitect.LOGGER.info(
+                            "Found structure {} at ({}, {}, {}) in {}",
+                            registry.getId(structure),
+                            center.getX(), center.getY(), center.getZ(),
+                            world.getRegistryKey().getValue());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `StructureLocator` to register chunk load events and log structures in each chunk
- initialize `StructureLocator` from the mod initializer

## Testing
- `./gradlew build` *(fails: Plugin not found due to blocked access)*