### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,5 +1,7 @@
 # Scan repository for secrets on push and pull requests
 name: secret-scan
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/0xCoDSnet/RoadArchitect/security/code-scanning/1](https://github.com/0xCoDSnet/RoadArchitect/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or job definition, specifying the minimal permissions required. In this case, since the workflow only checks out code and runs a scan, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the workflow level (above `jobs:`), which will apply to all jobs in the workflow unless overridden. This change should be made at the top of the file, after the `name:` and before the `on:` or `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
