### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@
 # against bad commits.
 
 name: build
+permissions:
+  contents: read
 on: [pull_request, push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/0xCoDSnet/RoadArchitect/security/code-scanning/2](https://github.com/0xCoDSnet/RoadArchitect/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The minimal starting point recommended by CodeQL is `contents: read`, which allows the workflow to read repository contents but not modify them. This block can be added either at the root of the workflow (applies to all jobs) or at the job level (applies only to the specified job). Since there is only one job in this workflow, adding it at the root is simplest and most maintainable. You should insert the following block after the `name: build` line and before the `on:` line in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
