### PR TITLE
v1.6.3 — Cache stability hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ target
 # Eclipse
 .classpath
 .settings
+.eclipse/
+**/.eclipse/
+
+# Runtime logs from runClient/runServer
+logs/
+**/logs/
 
 # installed Fabric binaries etc.
 /bin/

--- a/.gitignore
+++ b/.gitignore
@@ -29,15 +29,13 @@ target
 logs/
 **/logs/
 
-# installed Fabric binaries etc.
+# Hyperledger-Fabric template leftovers (project root only — must NOT shadow
+# Java packages such as src/.../config/)
 /bin/
-builders/
-config/
-external-chaincode/
-install-fabric.sh
-
-# override the ignore of all config/ folders
-!full-stack-asset-transfer-guide/infrastructure/sample-network/config
+/builders/
+/config/
+/external-chaincode/
+/install-fabric.sh
 
 
 # MacOS junk files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v1.6.3 — <em>Cache stability hotfix</em>
 
 ### Tuning
 - ⚖️ **Smarter default RAM split.** Default Cache budgets retuned for typical 2–4 GB heap setups: runtime 256 → 128 MiB, snapshots 64 → 32 MiB, pages 128 → 192 MiB. Total drops from 448 to 352 MiB while the main page cache grows by 50 % — hot regions stay in RAM instead of being read from disk on every chunk load. Existing configs are untouched; only fresh installs pick up the new values (use Cache → Reset to defaults if you want them).
+- ⚡ **No more multi-second freezes when loading into a world.** Cache writes triggered by chunk loads are now handled on a background worker. Returning to a world with hundreds of chunks streaming in at once no longer stalls the server tick for seconds while region files decompress.
 
 Compatibility: existing caches are read as before, no world migration needed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ v1.6.3 — <em>Cache stability hotfix</em>
 - 💾 **Hardened cache writes.** Cache files are now flushed to disk before being committed, so a server kill or power loss while saving no longer leaves you with a `ZipException: invalid stored block lengths` on the next launch.
 - 🚀 **Memory budget actually respected.** The cache previously underestimated its own size and could keep growing past the configured RAM limit, dragging TPS down. The accounting is fixed — the limit you set in the Cache config now reflects reality.
 
+### Tuning
+- ⚖️ **Smarter default RAM split.** Default Cache budgets retuned for typical 2–4 GB heap setups: runtime 256 → 128 MiB, snapshots 64 → 32 MiB, pages 128 → 192 MiB. Total drops from 448 to 352 MiB while the main page cache grows by 50 % — hot regions stay in RAM instead of being read from disk on every chunk load. Existing configs are untouched; only fresh installs pick up the new values (use Cache → Reset to defaults if you want them).
+
 Compatibility: existing caches are read as before, no world migration needed.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+v1.6.3 — <em>Cache stability hotfix</em>
+
+### Fixes
+- 🛡️ **Corrupted cache files no longer poison your world.** If a region cache file ever ends up unreadable (after a server kill, disk hiccup, or any other failure), it is now safely set aside and the cache rebuilds from scratch — instead of silently spreading the damage across new writes.
+- 💾 **Hardened cache writes.** Cache files are now flushed to disk before being committed, so a server kill or power loss while saving no longer leaves you with a `ZipException: invalid stored block lengths` on the next launch.
+- 🚀 **Memory budget actually respected.** The cache previously underestimated its own size and could keep growing past the configured RAM limit, dragging TPS down. The accounting is fixed — the limit you set in the Cache config now reflects reality.
+
+Compatibility: existing caches are read as before, no world migration needed.
+
+---
+
 v1.6.2 — <em>Cache stack overhaul</em>
 
 ### Highlights

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/config/RoadArchitectConfigData.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/config/RoadArchitectConfigData.java
@@ -228,17 +228,26 @@ public final class RoadArchitectConfigData implements ConfigData {
     }
 
     public static final class CacheSection {
+        // Defaults rebalanced for typical 2-4 GB heap setups:
+        //   runtime  128 MiB ≈ render distance 32 fully resident (~95 MiB at peak,
+        //                       ~88 b/ColumnRecord);
+        //   snapshot 32  MiB  covers render distance ~96 (1 KiB per chunk);
+        //   pages    192 MiB  holds 6 full 32-chunk regions (~32 MiB each), so
+        //                       render distance 32 fits without disk thrash.
+        // Total ≈ 352 MiB vs. previous 448 MiB, with the largest tier (pages)
+        // grown by 50 % — hot regions fit in RAM instead of being re-paged
+        // from disk on every chunk load.
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 16, max = 4096)
-        public int runtimeBudgetMb = 256;
+        public int runtimeBudgetMb = 128;
 
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 16, max = 1024)
-        public int snapshotBudgetMb = 64;
+        public int snapshotBudgetMb = 32;
 
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 16, max = 4096)
-        public int persistedBudgetMb = 128;
+        public int persistedBudgetMb = 192;
 
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 4, max = 128)

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/config/records/CacheSettings.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/config/records/CacheSettings.java
@@ -27,11 +27,14 @@ public record CacheSettings(
     private static final double HEAP_FRACTION = 0.65;
     private static final int MIN_CACHE_MB = 16;
 
+    // Keep in sync with RoadArchitectConfigData.CacheSection defaults — both
+    // surfaces must agree, otherwise tests / direct CacheSettings.DEFAULT
+    // consumers diverge from what players see in the GUI.
     public static final CacheSettings DEFAULT = new CacheSettings(
-            256,
             128,
-            256,
-            128,
+            32,
+            192,
+            32,
             true,
             2048,
             true,

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStore.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStore.java
@@ -20,9 +20,14 @@ import net.minecraft.world.level.biome.Biome;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 
 /**
@@ -95,13 +100,14 @@ final class RegionColumnStore {
 
     private RegionData loadRegion(long regionKey) {
         Path path = regionPath(regionKey);
-        RegionData data = new RegionData();
         if (!Files.exists(path)) {
-            return data;
+            return new RegionData();
         }
+        RegionData data = new RegionData();
         try (var in = Files.newInputStream(path)) {
             CompoundTag tag = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
             if (tag == null) {
+                data.markClean();
                 return data;
             }
             ListTag list = tag.getList(LIST_KEY, Tag.TAG_COMPOUND);
@@ -124,11 +130,37 @@ final class RegionColumnStore {
                     data.putLoaded(columnKey, record);
                 }
             }
-        } catch (IOException e) {
-            LOGGER.error("Failed to load cached region {}", path, e);
+            data.markClean();
+            return data;
+        } catch (IOException | RuntimeException e) {
+            // Corrupt or unreadable region: a partial RegionData would otherwise be
+            // cached and (since it stays dirty=false) silently overwrite the file
+            // on the next flush, propagating the corruption forever.
+            LOGGER.warn("Cached region {} is corrupted, quarantining and rebuilding from scratch", path, e);
+            quarantineCorruptedRegion(path);
+            return new RegionData();
         }
-        data.markClean();
-        return data;
+    }
+
+    static void quarantineCorruptedRegion(Path path) {
+        if (path == null) {
+            return;
+        }
+        try {
+            if (!Files.exists(path)) {
+                return;
+            }
+            Path target = path.resolveSibling(path.getFileName().toString() + ".corrupt-" + System.currentTimeMillis());
+            Files.move(path, target, StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.warn("Quarantined corrupted region {} -> {}", path, target);
+        } catch (IOException e) {
+            LOGGER.error("Failed to quarantine corrupted region {}, attempting delete", path, e);
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException deleteException) {
+                LOGGER.error("Failed to delete corrupted region {}", path, deleteException);
+            }
+        }
     }
 
     private void flushRegion(long regionKey, RegionData region) {
@@ -171,12 +203,46 @@ final class RegionColumnStore {
         }
         root.put(LIST_KEY, list);
 
+        // Buffer the GZIP'ed NBT in memory so we can fsync the on-disk file
+        // before atomically renaming it. Without force(true) the rename can
+        // succeed while the data block is still in the page cache — a kill -9
+        // or power loss then leaves a non-empty file with garbage payload,
+        // surfacing as ZipException("invalid stored block lengths") on the
+        // next read.
+        byte[] payload;
+        try {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream(8192);
+            NbtIo.writeCompressed(root, buffer);
+            payload = buffer.toByteArray();
+        } catch (IOException e) {
+            LOGGER.error("Failed to serialize cache region {}", path, e);
+            return;
+        }
+
         Path tmp = path.resolveSibling(path.getFileName().toString() + ".tmp");
-        try (var out = Files.newOutputStream(tmp)) {
-            NbtIo.writeCompressed(root, out);
-            Files.move(tmp, path, java.nio.file.StandardCopyOption.REPLACE_EXISTING, java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+        try (FileChannel channel = FileChannel.open(
+                tmp,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING)) {
+            ByteBuffer view = ByteBuffer.wrap(payload);
+            while (view.hasRemaining()) {
+                channel.write(view);
+            }
+            channel.force(true);
         } catch (IOException e) {
             LOGGER.error("Failed to write cache region {}", path, e);
+            try {
+                Files.deleteIfExists(tmp);
+            } catch (IOException ignored) {
+            }
+            return;
+        }
+
+        try {
+            Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            LOGGER.error("Failed to atomically move cache region {} -> {}", tmp, path, e);
             try {
                 Files.deleteIfExists(tmp);
             } catch (IOException ignored) {
@@ -258,7 +324,12 @@ final class RegionColumnStore {
         }
 
         synchronized int weightBytes() {
-            return Math.max(1, columns.size()) * 64;
+            // Approx. per-entry footprint: long key (8) + ColumnRecord (height 4 +
+            // stability 8 + biome Holder ~16) + Long2ObjectMap.Entry overhead (~24)
+            // + ResourceLocation string accounted in serialized form (~60).
+            // 64 b/entry was a wild underestimate — Caffeine's maximumWeight then
+            // failed to evict regions, letting the cache grow unbounded.
+            return Math.max(1, columns.size()) * 128;
         }
     }
 }

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/CacheManager.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/CacheManager.java
@@ -352,9 +352,11 @@ public final class CacheManager {
         if (surface == null) {
             surface = wg;
         }
-        int[] snapshot = new int[COLUMNS_PER_CHUNK];
 
-        CacheStorage storage = state.storage();
+        // Read the heightmap synchronously while the chunk is guaranteed
+        // present on the server thread; the resulting int[] is a self-contained
+        // copy and is safe to consume from a worker.
+        int[] snapshot = new int[COLUMNS_PER_CHUNK];
         for (int localZ = 0; localZ < CHUNK_SIDE; localZ++) {
             for (int localX = 0; localX < CHUNK_SIDE; localX++) {
                 int idx = localZ * CHUNK_SIDE + localX;
@@ -363,13 +365,31 @@ public final class CacheManager {
                     height = surface.getFirstAvailable(localX, localZ);
                 }
                 snapshot[idx] = height;
-                long key = hash(startX + localX, startZ + localZ);
-                storage.putHeight(key, height);
             }
         }
 
-        state.putChunkSnapshot(pos.toLong(), new ChunkHeightSnapshot(snapshot, CHUNK_SIDE));
-        DebugLog.cache(LOGGER, "Chunk snapshot refreshed for {} ({})", pos, world.dimension().location());
+        // Defer the 256 column writes and the snapshot publication to the
+        // async pool. Each storage.putHeight() goes through CacheStorage.mutate
+        // → RegionColumnStore.write → regions.get(loadRegion), which on a
+        // cold cache miss synchronously GZIP-decodes a ~tens-of-MiB region
+        // file. Doing that 256× per chunk on the server thread, multiplied
+        // by 200+ chunk-loads/second on world reload, was the cause of the
+        // multi-second tick freezes. Caffeine's runtime + region caches and
+        // the snapshot map are all thread-safe, so deferring is a drop-in.
+        long chunkKey = pos.toLong();
+        ResourceKey<Level> dimensionKey = world.dimension();
+        AsyncExecutor.execute(() -> {
+            CacheStorage storage = state.storage();
+            for (int localZ = 0; localZ < CHUNK_SIDE; localZ++) {
+                for (int localX = 0; localX < CHUNK_SIDE; localX++) {
+                    int idx = localZ * CHUNK_SIDE + localX;
+                    long key = hash(startX + localX, startZ + localZ);
+                    storage.putHeight(key, snapshot[idx]);
+                }
+            }
+            state.putChunkSnapshot(chunkKey, new ChunkHeightSnapshot(snapshot, CHUNK_SIDE));
+            DebugLog.cache(LOGGER, "Chunk snapshot refreshed for {} ({})", pos, dimensionKey.location());
+        });
     }
 
     /**

--- a/modules/common/src/test/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStoreQuarantineTest.java
+++ b/modules/common/src/test/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStoreQuarantineTest.java
@@ -1,0 +1,49 @@
+package net.oxcodsnet.roadarchitect.storage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegionColumnStoreQuarantineTest {
+
+    @Test
+    void quarantine_renames_file_with_corrupt_suffix(@TempDir Path dir) throws IOException {
+        Path region = dir.resolve("region_0_0.nbt");
+        Files.write(region, "corrupted-payload".getBytes(StandardCharsets.UTF_8));
+
+        RegionColumnStore.quarantineCorruptedRegion(region);
+
+        assertFalse(Files.exists(region), "original corrupt file must be moved away");
+        try (Stream<Path> files = Files.list(dir)) {
+            List<Path> survivors = files.toList();
+            assertEquals(1, survivors.size(), "expected exactly one quarantined file");
+            Path target = survivors.get(0);
+            assertTrue(target.getFileName().toString().startsWith("region_0_0.nbt.corrupt-"),
+                    "quarantined file must keep the original name and gain a corrupt-{ts} suffix, got: " + target.getFileName());
+            assertEquals("corrupted-payload",
+                    Files.readString(target, StandardCharsets.UTF_8),
+                    "quarantine must preserve the original bytes for offline diagnosis");
+        }
+    }
+
+    @Test
+    void quarantine_is_noop_when_file_does_not_exist(@TempDir Path dir) {
+        Path missing = dir.resolve("region_42_-7.nbt");
+        assertDoesNotThrow(() -> RegionColumnStore.quarantineCorruptedRegion(missing));
+        assertFalse(Files.exists(missing));
+    }
+
+    @Test
+    void quarantine_tolerates_null(@TempDir Path dir) {
+        // Defensive: Caffeine wiring can in principle hand a null path through.
+        assertDoesNotThrow(() -> RegionColumnStore.quarantineCorruptedRegion(null));
+    }
+}


### PR DESCRIPTION
## Summary

Three independent fixes converging on the cache backend, plus a defaults rebalance. Closes the long-standing performance regression reported in #28 and likely tied to the heavy load reports in #14, #32, #41.

## Commits

- `7625298` **fix(cache): stop cumulative corruption of region cache files** — `RegionColumnStore.loadRegion` quarantines corrupt files (`region_X_Z.nbt.corrupt-{ts}`) instead of caching a partially loaded `RegionData` and silently overwriting it on the next flush. `flushRegion` now writes through `FileChannel.force(true)` before `ATOMIC_MOVE` so a `kill -9` / power loss during the GZIP write no longer leaves a non-empty file with garbage payload (the `ZipException: invalid stored block lengths` source on Cobblemon servers). `RegionData.weightBytes` 64 → 128 b/entry; the old estimate was off by ~2x and Caffeine's `maximumWeight` never evicted regions, letting the cache grow unbounded.
- `3d713a8` **chore: ignore runClient logs and Eclipse metadata** — `**/logs/`, `**/.eclipse/`.
- `202e514` **fix(cache): rebalance default RAM budgets** — `RoadArchitectConfigData.cache()` and `CacheSettings.DEFAULT` now agree on `runtimeBudgetMb=128`, `snapshotBudgetMb=32`, `persistedBudgetMb=192`, `regionSizeChunks=32`. Total drops from 448 to 352 MiB, while the largest tier (pages) grows by 50% — hot regions stay in RAM instead of being re-paged from disk on every chunk load. Existing configs untouched. Also anchors the Hyperledger-Fabric template leftovers in `.gitignore` so they no longer shadow `src/.../config/` Java packages.
- `306f75b` **fix(cache): defer chunk-load cache writes to async pool** — `CacheManager.onChunkLoad` reads the heightmap into a local `int[]` on the server thread (chunk guaranteed present) and dispatches the 256 `storage.putHeight()` calls plus `state.putChunkSnapshot` to `AsyncExecutor`. Eliminates the multi-second tick freezes on world reload caused by sync `loadRegion` (GZIP decode of tens of MiB) cascading through chunk-load bursts.

## Background

`RegionColumnStore.loadRegion` swallowed `IOException` and returned a partially populated `RegionData` while still calling `markClean()`. Caffeine cached it, the next flush produced a snapshot of incomplete data, `ATOMIC_MOVE`'d it over the original, and a one-off read failure became permanent corruption that grew with every save. Combined with `RegionData.weightBytes` under-counting by ~2x (so eviction never fired), this is the most plausible explanation for the recurring "huge `road_cache.dat`" reports after the v1.5.0 / v1.6.2 fixes.

The defaults rebalance is driven by realistic per-render-distance footprint:
| render | runtime | snapshots | regions |
|---|---|---|---|
| 12 | ~14 MiB | ~0.6 MiB | 1–2 |
| 24 | ~54 MiB | ~2.4 MiB | 4–6 |
| 32 | ~95 MiB | ~4.1 MiB | 6–9 |

Old defaults (256/64/128) over-allocated the runtime tier ~5x while under-budgeting pages — at 32-chunk regions ~32 MiB each, only ~4 fit in 128 MiB and spilled to disk. New defaults match the curve at render 32 without overshooting render 12.

## Validation

- `:modules:common:test` — 24 tests passing, including 3 new `RegionColumnStoreQuarantineTest` cases covering corrupt-file rename, no-op on missing file, and null-tolerance.
- `:modules:fabric:build` and `:modules:neoforge:build` clean (compileJava, jarJar, remapJar).
- Live `runClient` testing on a 2 GB heap with a fresh config:
  - Average tick dropped from 65–77 ms (pre-fix bewe3 reports) to 14–22 ms.
  - Max tick spike on world reload dropped from 5062 ms to 169 ms (cache-side); a separate 3641 ms spike remained but tracks to `StructureLocator.chunk_load` (sync vanilla worldgen during structure confirmation), out of scope here.
  - Caffeine page eviction now actually fires at the budget ceiling; no `Quarantined` / `corrupted` events under normal play.
  - Heightmap snapshots logged on `ForkJoinPool-4-worker-N` instead of the server thread, confirming the async dispatch.

## Compatibility

- Region file format unchanged — existing caches read as before.
- Existing `roadarchitect.json` files are untouched. Players opting into the rebalanced budgets need *Cache → Reset to defaults* in the config UI, or to delete their config.
- No mixin / API surface changes.