### PR TITLE
v1.6.5 — Config robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v1.6.5 — <em>Config robustness</em>
+
+### Fixes
+- 🛡️ **Broken selector lists no longer crash the mod.** A truncated or partially-corrupt config file (e.g. after a game crash mid-write) sometimes left `null` entries inside `structureSelectors` / `dimensionSelectors` / `forbiddenBiomes.selectors`. These are now filtered out at load time and the mod keeps running on whatever entries are still valid.
+- 💬 **Helpful hint when a structure id is mistyped.** Invalid selectors used to log a flat `Structure selector 'X' is invalid`. The mod now searches the registry for the closest-matching id or tag and adds `did you mean 'Y'?` — handy when adding ids from Mo' Structures, Tectonic, etc.
+
+---
+
 v1.6.4 — <em>Config & performance toggles</em>
 
 ### Added

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/ConfigSanitize.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/ConfigSanitize.java
@@ -1,0 +1,32 @@
+package net.oxcodsnet.roadarchitect.util;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Defensive helpers for cleaning user-editable config values before they
+ * reach the runtime. Cloth-Config can produce a {@code null}-laden list
+ * when a JSON file is partially corrupt (e.g. truncated by a crash mid-write,
+ * see PeachyKeen's report on Discord 2025-12-30) — the rest of the mod
+ * happily NPEs from there. Filtering once at the bridge keeps the rest of
+ * the codebase free of {@code null}/blank guards.
+ */
+public final class ConfigSanitize {
+    private ConfigSanitize() {}
+
+    /**
+     * Returns an immutable list with {@code null} and blank entries
+     * removed and remaining strings trimmed. {@code null} input maps to
+     * an empty list — never propagates upward.
+     */
+    public static List<String> cleanList(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
+        return raw.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/StringSimilarity.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/StringSimilarity.java
@@ -1,0 +1,81 @@
+package net.oxcodsnet.roadarchitect.util;
+
+import java.util.Collection;
+
+/**
+ * Tiny Levenshtein-distance helpers used to suggest the nearest valid
+ * value when a user-provided string (config selector, tag id, …) does
+ * not match anything in the registry.
+ *
+ * <p>The implementation is intentionally dependency-free and small:
+ * config-time validation runs once per selector and cache misses are
+ * rare, so the {@code O(n·m)} dynamic-programming variant is good
+ * enough — no need to pull in commons-text or similar.
+ */
+public final class StringSimilarity {
+    private StringSimilarity() {}
+
+    /**
+     * Edit distance between {@code a} and {@code b}.
+     */
+    public static int levenshtein(String a, String b) {
+        if (a == null || b == null) {
+            throw new IllegalArgumentException("inputs must be non-null");
+        }
+        if (a.equals(b)) return 0;
+        if (a.isEmpty()) return b.length();
+        if (b.isEmpty()) return a.length();
+
+        int[] prev = new int[b.length() + 1];
+        int[] curr = new int[b.length() + 1];
+        for (int j = 0; j <= b.length(); j++) prev[j] = j;
+
+        for (int i = 1; i <= a.length(); i++) {
+            curr[0] = i;
+            char ai = a.charAt(i - 1);
+            for (int j = 1; j <= b.length(); j++) {
+                int cost = ai == b.charAt(j - 1) ? 0 : 1;
+                int del = prev[j] + 1;
+                int ins = curr[j - 1] + 1;
+                int sub = prev[j - 1] + cost;
+                curr[j] = Math.min(Math.min(del, ins), sub);
+            }
+            int[] tmp = prev;
+            prev = curr;
+            curr = tmp;
+        }
+        return prev[b.length()];
+    }
+
+    /**
+     * Returns the single best match in {@code candidates} for {@code input},
+     * or {@code null} when nothing is within {@code maxDistance} edits.
+     */
+    public static String bestMatch(String input, Collection<String> candidates, int maxDistance) {
+        if (input == null || candidates == null || candidates.isEmpty() || maxDistance < 0) {
+            return null;
+        }
+        String best = null;
+        int bestDist = Integer.MAX_VALUE;
+        for (String candidate : candidates) {
+            if (candidate == null) continue;
+            int d = levenshtein(input, candidate);
+            if (d < bestDist) {
+                bestDist = d;
+                best = candidate;
+                if (d == 0) break;
+            }
+        }
+        return bestDist <= maxDistance ? best : null;
+    }
+
+    /**
+     * Suggestion threshold tuned for IDs/tag paths: 2 edits for short
+     * strings, ~25% of the length for longer ones — catches typos and
+     * one-letter mix-ups without yielding wild guesses.
+     */
+    public static int defaultThresholdFor(String input) {
+        if (input == null || input.isEmpty()) return 0;
+        return Math.max(2, input.length() / 4);
+    }
+}

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/StructureLocator.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/util/StructureLocator.java
@@ -68,6 +68,9 @@ public final class StructureLocator {
     private static final Map<Registry<Structure>, Map<String, HolderSet<Structure>>> SELECTOR_CACHE = new WeakHashMap<>();
 
     private static List<HolderSet<Structure>> compileSelectors(Registry<Structure> registry, List<String> selectors) {
+        if (selectors == null || selectors.isEmpty()) {
+            return List.of();
+        }
         Map<String, HolderSet<Structure>> cache =
                 SELECTOR_CACHE.computeIfAbsent(registry, r -> new HashMap<>(selectors.size() * 2));
 
@@ -75,6 +78,11 @@ public final class StructureLocator {
         List<HolderSet<Structure>> compiled = new ArrayList<>(selectors.size());
 
         for (String raw : selectors) {
+            // Defensive: bridges already sanitize, but a corrupt config or a
+            // direct API caller might still send null/blank entries.
+            if (raw == null || raw.isBlank()) {
+                continue;
+            }
             HolderSet<Structure> list = cache.get(raw);
             if (list == null) {
                 try {
@@ -83,13 +91,37 @@ public final class StructureLocator {
                             .orElseThrow(() -> INVALID_STRUCTURE_EXCEPTION.create(raw));
                     cache.put(raw, list);
                 } catch (CommandSyntaxException ex) {
-                    LOGGER.warn("Structure selector '{}' is invalid: {}", raw, ex.getMessage());
+                    String suggestion = suggestNearestSelector(raw, registry);
+                    if (suggestion != null) {
+                        LOGGER.warn("Structure selector '{}' is invalid: {} — did you mean '{}'?",
+                                raw, ex.getMessage(), suggestion);
+                    } else {
+                        LOGGER.warn("Structure selector '{}' is invalid: {}", raw, ex.getMessage());
+                    }
                     continue;
                 }
             }
             compiled.add(list);
         }
         return compiled;
+    }
+
+    /**
+     * Combines structure ids and tag ids from {@code registry} and returns the
+     * closest match for {@code raw} via Levenshtein distance. The tag pool is
+     * prefixed with {@code #} so the suggestion preserves the syntax the user
+     * likely intended.
+     */
+    private static String suggestNearestSelector(String raw, Registry<Structure> registry) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        List<String> candidates = new ArrayList<>(registry.size() + 32);
+        for (ResourceLocation id : registry.keySet()) {
+            candidates.add(id.toString());
+        }
+        registry.getTagNames().forEach(tag -> candidates.add("#" + tag.location()));
+        return StringSimilarity.bestMatch(raw, candidates, StringSimilarity.defaultThresholdFor(raw));
     }
 
     /* ───────────────────────────── Public API ───────────────────────────── */

--- a/modules/common/src/test/java/net/oxcodsnet/roadarchitect/util/ConfigSanitizeTest.java
+++ b/modules/common/src/test/java/net/oxcodsnet/roadarchitect/util/ConfigSanitizeTest.java
@@ -1,0 +1,39 @@
+package net.oxcodsnet.roadarchitect.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigSanitizeTest {
+
+    @Test
+    void cleanList_returns_empty_for_null_input() {
+        assertEquals(List.of(), ConfigSanitize.cleanList(null));
+    }
+
+    @Test
+    void cleanList_returns_empty_for_empty_input() {
+        assertEquals(List.of(), ConfigSanitize.cleanList(List.of()));
+    }
+
+    @Test
+    void cleanList_drops_null_entries() {
+        List<String> input = Arrays.asList("a", null, "b", null);
+        assertEquals(List.of("a", "b"), ConfigSanitize.cleanList(input));
+    }
+
+    @Test
+    void cleanList_drops_blank_entries_and_trims() {
+        List<String> input = Arrays.asList("  minecraft:village  ", "", "   ", "\tmostructures:tavern_1\n");
+        assertEquals(List.of("minecraft:village", "mostructures:tavern_1"), ConfigSanitize.cleanList(input));
+    }
+
+    @Test
+    void cleanList_preserves_order_and_duplicates() {
+        List<String> input = Arrays.asList("x", "y", "x");
+        assertEquals(List.of("x", "y", "x"), ConfigSanitize.cleanList(input));
+    }
+}

--- a/modules/common/src/test/java/net/oxcodsnet/roadarchitect/util/StringSimilarityTest.java
+++ b/modules/common/src/test/java/net/oxcodsnet/roadarchitect/util/StringSimilarityTest.java
@@ -1,0 +1,66 @@
+package net.oxcodsnet.roadarchitect.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringSimilarityTest {
+
+    @Test
+    void levenshtein_zero_for_equal_strings() {
+        assertEquals(0, StringSimilarity.levenshtein("minecraft:village", "minecraft:village"));
+    }
+
+    @Test
+    void levenshtein_one_for_single_typo() {
+        assertEquals(1, StringSimilarity.levenshtein("village", "villag"));
+        assertEquals(1, StringSimilarity.levenshtein("village", "villag3"));
+        assertEquals(1, StringSimilarity.levenshtein("village", "villlage"));
+    }
+
+    @Test
+    void levenshtein_handles_empty_strings() {
+        assertEquals(0, StringSimilarity.levenshtein("", ""));
+        assertEquals(5, StringSimilarity.levenshtein("", "abcde"));
+        assertEquals(5, StringSimilarity.levenshtein("abcde", ""));
+    }
+
+    @Test
+    void bestMatch_returns_closest_candidate_within_threshold() {
+        List<String> candidates = List.of(
+                "minecraft:village",
+                "minecraft:pillager_outpost",
+                "mostructures:tavern_1"
+        );
+        assertEquals("minecraft:village", StringSimilarity.bestMatch("minecraft:vilage", candidates, 2));
+        assertEquals("mostructures:tavern_1", StringSimilarity.bestMatch("mostructures:tavern1", candidates, 2));
+    }
+
+    @Test
+    void bestMatch_returns_null_when_nothing_close_enough() {
+        List<String> candidates = List.of("minecraft:village", "minecraft:fortress");
+        assertNull(StringSimilarity.bestMatch("totally:unrelated", candidates, 2));
+    }
+
+    @Test
+    void bestMatch_tolerates_null_inputs() {
+        assertNull(StringSimilarity.bestMatch(null, List.of("a"), 2));
+        assertNull(StringSimilarity.bestMatch("a", null, 2));
+        assertNull(StringSimilarity.bestMatch("a", List.of(), 2));
+    }
+
+    @Test
+    void bestMatch_skips_null_candidates() {
+        List<String> candidates = java.util.Arrays.asList(null, "minecraft:village", null);
+        assertEquals("minecraft:village", StringSimilarity.bestMatch("minecraft:vilage", candidates, 2));
+    }
+
+    @Test
+    void defaultThresholdFor_scales_with_length() {
+        assertEquals(2, StringSimilarity.defaultThresholdFor("village"));
+        assertEquals(2, StringSimilarity.defaultThresholdFor("a"));
+        assertTrue(StringSimilarity.defaultThresholdFor("minecraft:pillager_outpost") >= 2);
+    }
+}

--- a/modules/fabric/src/main/java/net/oxcodsnet/roadarchitect/fabric/config/RAConfigFabricBridge.java
+++ b/modules/fabric/src/main/java/net/oxcodsnet/roadarchitect/fabric/config/RAConfigFabricBridge.java
@@ -93,12 +93,12 @@ public final class RAConfigFabricBridge {
 
             @Override
             public java.util.List<String> structureSelectors() {
-                return holder.getConfig().structureSelectors;
+                return net.oxcodsnet.roadarchitect.util.ConfigSanitize.cleanList(holder.getConfig().structureSelectors);
             }
 
             @Override
             public java.util.List<String> dimensionSelectors() {
-                return holder.getConfig().dimensionSelectors;
+                return net.oxcodsnet.roadarchitect.util.ConfigSanitize.cleanList(holder.getConfig().dimensionSelectors);
             }
 
             // Terrain Analyzer
@@ -151,7 +151,7 @@ public final class RAConfigFabricBridge {
             // Forbidden biomes
             @Override
             public java.util.List<String> forbiddenBiomeSelectors() {
-                return holder.getConfig().forbiddenBiomes.selectors;
+                return net.oxcodsnet.roadarchitect.util.ConfigSanitize.cleanList(holder.getConfig().forbiddenBiomes.selectors);
             }
 
             @Override

--- a/modules/neoforge/src/main/java/net/oxcodsnet/roadarchitect/neoforge/config/RAConfigNeoForgeBridge.java
+++ b/modules/neoforge/src/main/java/net/oxcodsnet/roadarchitect/neoforge/config/RAConfigNeoForgeBridge.java
@@ -88,12 +88,12 @@ public final class RAConfigNeoForgeBridge {
 
             @Override
             public java.util.List<String> structureSelectors() {
-                return holder.getConfig().structureSelectors;
+                return net.oxcodsnet.roadarchitect.util.ConfigSanitize.cleanList(holder.getConfig().structureSelectors);
             }
 
             @Override
             public java.util.List<String> dimensionSelectors() {
-                return holder.getConfig().dimensionSelectors;
+                return net.oxcodsnet.roadarchitect.util.ConfigSanitize.cleanList(holder.getConfig().dimensionSelectors);
             }
 
             // Terrain Analyzer
@@ -146,7 +146,7 @@ public final class RAConfigNeoForgeBridge {
             // Forbidden biomes
             @Override
             public java.util.List<String> forbiddenBiomeSelectors() {
-                return holder.getConfig().forbiddenBiomes.selectors;
+                return net.oxcodsnet.roadarchitect.util.ConfigSanitize.cleanList(holder.getConfig().forbiddenBiomes.selectors);
             }
 
             @Override


### PR DESCRIPTION
## Summary

Two small, defensive improvements to selector handling that close two recurring user pain points:

1. **`null` / blank entries in selector lists no longer crash the mod.** A partially-corrupt config (e.g. JSON truncated by a crash mid-write — see PeachyKeen's report on Discord, 2025-12-30) used to slip a literal `null` into `structureSelectors`, which then NPE'd inside `StructureLocator.compileSelectors`. All three list-style fields (`structureSelectors`, `dimensionSelectors`, `forbiddenBiomes.selectors`) now pass through `ConfigSanitize.cleanList()` in both Fabric and NeoForge bridges — null/blank entries are dropped, remaining strings trimmed, and the mod runs on whatever stays valid.

2. **Invalid selectors now suggest the closest valid id.** Previously the warning was just `Structure selector 'X' is invalid: There is no structure with type "X"` — useless when you mistyped an id from Mo' Structures or Tectonic. `compileSelectors` now searches the registry's structure ids and tag names via Levenshtein and, when a candidate is within a length-scaled threshold (`max(2, len/4)`), appends ` — did you mean 'Y'?` to the warning. Tags keep their `#` prefix so the suggestion preserves the syntax the user intended.

## Files

- `util/ConfigSanitize.java` — null/blank list filter (new).
- `util/StringSimilarity.java` — dependency-free Levenshtein + best-match (new).
- `util/StructureLocator.java` — defensive null guard in `compileSelectors`, suggestion plumbed into the failure path.
- `RAConfigFabricBridge.java` / `RAConfigNeoForgeBridge.java` — three accessors routed through `ConfigSanitize.cleanList`.
- `ConfigSanitizeTest` (5 cases) + `StringSimilarityTest` (8 cases).

## Validation

- `:modules:common:test` — 37 tests green (5 new for sanitize, 8 new for similarity, no regressions).
- `:modules:fabric:build` and `:modules:neoforge:build` clean.