### PR TITLE
v1.6.6 — Cache flush race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v1.6.6 — <em>Cache flush race fix</em>
+
+### Fixes
+- 🧵 **No more `NoSuchFileException` spam in the log when the cache is busy.** Two background workers could try to save the same region at the same moment and step on each other's temporary file, leaving a stack trace in the log every time it happened. Each save now uses its own private temp file, and any leftovers from a previous crashed run are cleaned up at startup.
+
+---
+
 v1.6.5 — <em>Config robustness</em>
 
 ### Fixes

--- a/modules/common/src/main/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStore.java
+++ b/modules/common/src/main/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStore.java
@@ -29,6 +29,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * Region-paged persistence layer for cached column data.
@@ -67,6 +69,7 @@ final class RegionColumnStore {
                 .weigher((Long key, RegionData value) -> value.weightBytes())
                 .removalListener(this::onRegionRemoval)
                 .build();
+        cleanOrphanedTempFiles(this.regionDir);
     }
 
     ColumnRecord read(long columnKey) {
@@ -139,6 +142,34 @@ final class RegionColumnStore {
             LOGGER.warn("Cached region {} is corrupted, quarantining and rebuilding from scratch", path, e);
             quarantineCorruptedRegion(path);
             return new RegionData();
+        }
+    }
+
+    /**
+     * Sweeps stray {@code region_X_Z.nbt.tmp.*} files left over from a
+     * previous JVM that crashed mid-write. Safe to run once at startup —
+     * by definition no other thread is touching the cache directory yet.
+     */
+    static void cleanOrphanedTempFiles(Path regionDir) {
+        if (regionDir == null || !Files.isDirectory(regionDir)) {
+            return;
+        }
+        try (Stream<Path> stream = Files.list(regionDir)) {
+            stream
+                    .filter(p -> {
+                        String name = p.getFileName().toString();
+                        return name.startsWith("region_") && name.contains(".nbt.tmp");
+                    })
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                            LOGGER.debug("Removed orphaned cache temp file {}", p);
+                        } catch (IOException e) {
+                            LOGGER.warn("Failed to remove orphaned cache temp file {}", p, e);
+                        }
+                    });
+        } catch (IOException e) {
+            LOGGER.warn("Failed to scan cache directory for orphaned temp files: {}", regionDir, e);
         }
     }
 
@@ -219,7 +250,15 @@ final class RegionColumnStore {
             return;
         }
 
-        Path tmp = path.resolveSibling(path.getFileName().toString() + ".tmp");
+        // Unique tmp suffix per call: Caffeine's removalListener runs on
+        // ForkJoinPool.commonPool, so the same regionKey can be flushed by
+        // two workers concurrently (evict → reload → evict in quick
+        // succession). With a shared "${name}.tmp" filename, the second
+        // worker raced the first and lost — the first ATOMIC_MOVE consumed
+        // the tmp file, the second one then failed with NoSuchFileException
+        // mid-flight. A UUID suffix isolates the workers; the orphan
+        // cleanup at construction time picks up any file the JVM died on.
+        Path tmp = path.resolveSibling(path.getFileName().toString() + ".tmp." + UUID.randomUUID());
         try (FileChannel channel = FileChannel.open(
                 tmp,
                 StandardOpenOption.CREATE,

--- a/modules/common/src/test/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStoreOrphanCleanupTest.java
+++ b/modules/common/src/test/java/net/oxcodsnet/roadarchitect/storage/RegionColumnStoreOrphanCleanupTest.java
@@ -1,0 +1,53 @@
+package net.oxcodsnet.roadarchitect.storage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegionColumnStoreOrphanCleanupTest {
+
+    @Test
+    void cleanOrphanedTempFiles_removes_only_temp_artifacts(@TempDir Path dir) throws IOException {
+        Path keep1 = Files.writeString(dir.resolve("region_0_0.nbt"), "real-region");
+        Path keep2 = Files.writeString(dir.resolve("region_-3_4.nbt.corrupt-1234567"), "quarantined");
+        Path keep3 = Files.writeString(dir.resolve("metadata.json"), "{}");
+        Path orphan1 = Files.writeString(dir.resolve("region_0_0.nbt.tmp." + UUID.randomUUID()), "stale-1");
+        Path orphan2 = Files.writeString(dir.resolve("region_-2_5.nbt.tmp.another"), "stale-2");
+
+        RegionColumnStore.cleanOrphanedTempFiles(dir);
+
+        assertTrue(Files.exists(keep1), "real region must survive cleanup");
+        assertTrue(Files.exists(keep2), "quarantined file must survive cleanup");
+        assertTrue(Files.exists(keep3), "unrelated files must survive cleanup");
+        assertFalse(Files.exists(orphan1), "uuid-suffixed tmp must be removed");
+        assertFalse(Files.exists(orphan2), "any region_*.nbt.tmp.* must be removed");
+    }
+
+    @Test
+    void cleanOrphanedTempFiles_is_noop_on_missing_directory(@TempDir Path dir) {
+        Path missing = dir.resolve("nonexistent-cache");
+        assertDoesNotThrow(() -> RegionColumnStore.cleanOrphanedTempFiles(missing));
+    }
+
+    @Test
+    void cleanOrphanedTempFiles_tolerates_null() {
+        assertDoesNotThrow(() -> RegionColumnStore.cleanOrphanedTempFiles(null));
+    }
+
+    @Test
+    void cleanOrphanedTempFiles_handles_empty_directory(@TempDir Path dir) throws IOException {
+        RegionColumnStore.cleanOrphanedTempFiles(dir);
+        try (Stream<Path> entries = Files.list(dir)) {
+            assertEquals(List.of(), entries.toList());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A 5-line race fix discovered while live-testing PR #44.

`RegionColumnStore.flushRegion` used a shared tmp path
(`region_X_Z.nbt.tmp`) for the buffered write before `ATOMIC_MOVE`. Caffeine's
`removalListener` runs on `ForkJoinPool.commonPool` by default, so the same
`regionKey` can be flushed by two workers concurrently when a region churns
through evict → reload → evict (typical at `pages: 99%` load). The first
worker's ATOMIC_MOVE consumed the tmp file; the second one then crashed with
`NoSuchFileException` mid-rename, logging a stack trace each time. Data on
disk stayed correct (the first move always succeeded), but the log noise
was real.

## Fix

- Each flush writes to `region_X_Z.nbt.tmp.<UUID>` — concurrent workers no
  longer share a tmp file.
- `RegionColumnStore` constructor now sweeps `region_*.nbt.tmp.*` orphans
  left by a crashed JVM. Safe to run there: the cache directory is opened
  before any worker can touch it.

## Validation

- New `RegionColumnStoreOrphanCleanupTest` (4 cases) covers: cleanup keeps
  real `region_*.nbt`, quarantine files and unrelated entries; sweep is a
  no-op on a missing/empty directory; tolerates `null`.
- `:modules:common:test` — 41 tests green (4 new, no regressions).
- `:modules:fabric:build` and `:modules:neoforge:build` clean.

## Notes

The original issue surfaced as `[ForkJoinPool.commonPool-worker-N/ERROR]
(RoadArchitect/RegionColumnStore) Failed to atomically move cache region
… NoSuchFileException` during the PR #44 robustness session.